### PR TITLE
Updated elasticsearch's url

### DIFF
--- a/bml/config.yml
+++ b/bml/config.yml
@@ -1,4 +1,4 @@
-elastic-host: elk.browbeatproject.org
+elastic-host: elk-b09-h30-r720xd.rdu.openstack.engineering.redhat.com
 elastic-port: 9200
 
 tests:


### PR DESCRIPTION
elk.browbeatproject.org has been buggy and hence pointed browbeat to elk-b09-h30-r720xd.rdu.openstack.engineering.redhat.com, thus pointing bml as well.